### PR TITLE
Array conversions for byte and Byte types.

### DIFF
--- a/commons-core/src/main/java/fr/inria/atlanmod/commons/collect/MoreArrays.java
+++ b/commons-core/src/main/java/fr/inria/atlanmod/commons/collect/MoreArrays.java
@@ -190,6 +190,29 @@ public final class MoreArrays {
     }
 
     /**
+     * Adds all {@code array2} at the end of the {@code array1}.
+     *
+     * @param array1    the array to add the element to
+     * @param array2    the values to add
+     *
+     * @return a new array of bytes containing all the existing elements in arrays 1 and 2.
+     *
+     * @throws NullPointerException if any argument is {@code null}
+     */
+    @Nonnull
+    public static byte[] addAll(byte[] array1, byte... array2) {
+        checkNotNull(array1, "array1");
+        checkNotNull(array2, "array2");
+
+        final byte[] newArray = new byte[array1.length + array2.length];
+        System.arraycopy(array1, 0, newArray, 0, array1.length);
+        System.arraycopy(array2, 0, newArray, array1.length, array2.length);
+
+        return newArray;
+
+    }
+
+    /**
      * Removes the element at the specified {@code index} from the specified {@code array}.
      *
      * @param array the array to remove the element from

--- a/commons-core/src/main/java/fr/inria/atlanmod/commons/collect/MoreArrays.java
+++ b/commons-core/src/main/java/fr/inria/atlanmod/commons/collect/MoreArrays.java
@@ -275,4 +275,39 @@ public final class MoreArrays {
 
         return NO_INDEX;
     }
+
+    /**
+     * Converts an array of {@link Byte} to an array of primitive types {@link byte}.
+     *
+     * @param boxedArray The array of {@link Byte} to convert.
+     * @return An array of {@link byte} containing the same elements as {@code boxedArray},
+     * in the same order, converted to primitives.
+     */
+    @Nonnull
+    public static byte[] toPrimitive(final Byte... boxedArray) {
+        checkNotNull(boxedArray, "boxedArray");
+        byte[] primitiveArray = new byte[boxedArray.length];
+        for (int i = 0; i < boxedArray.length; i++) {
+            primitiveArray[i] = boxedArray[i].byteValue();
+        }
+        return primitiveArray;
+    }
+
+    /**
+     * Converts an array of primitive types {@link byte} to an array of Objects {@Byte}.
+     *
+     * @param primitiveArray The array of {@linke byte} to convert.
+     *
+     * @return An array of {@link Byte}  containing the same elements as {@code primitiveArray}, in the same order,
+     * converted to boxed types.
+     */
+    public static Byte[] toObject(final byte... primitiveArray) {
+        checkNotNull(primitiveArray, "primitiveArray");
+        Byte[] boxedArray = new Byte[primitiveArray.length];
+
+        for (int i = 0; i < boxedArray.length; i++) {
+            boxedArray[i] = Byte.valueOf(primitiveArray[i]);
+        }
+        return boxedArray;
+    }
 }

--- a/commons-core/src/main/java/fr/inria/atlanmod/commons/primitive/Bytes.java
+++ b/commons-core/src/main/java/fr/inria/atlanmod/commons/primitive/Bytes.java
@@ -11,15 +11,13 @@ package fr.inria.atlanmod.commons.primitive;
 import fr.inria.atlanmod.commons.Throwables;
 import fr.inria.atlanmod.commons.annotation.Static;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 
 import static fr.inria.atlanmod.commons.Preconditions.checkEqualTo;
 import static fr.inria.atlanmod.commons.Preconditions.checkNotNull;
@@ -260,7 +258,7 @@ public final class Bytes {
         }
         List<Byte> byteCollection = new ArrayList<>(primitiveArray.length);
         for (byte each : primitiveArray) {
-            byteCollection.add(new Byte(each));
+            byteCollection.add(Byte.valueOf(each));
         }
         return byteCollection;
     }

--- a/commons-core/src/main/java/fr/inria/atlanmod/commons/primitive/Bytes.java
+++ b/commons-core/src/main/java/fr/inria/atlanmod/commons/primitive/Bytes.java
@@ -13,6 +13,10 @@ import fr.inria.atlanmod.commons.annotation.Static;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -238,4 +242,46 @@ public final class Bytes {
 
         return new String(result);
     }
+
+
+    /**
+     * Converts a {@code byte} array into a {@link List} of {@link Byte}.
+     *
+     * @param primitiveArray the {@code byte} array to convert
+     * @return A {@link List} containing the same elements as {@code primitiveArray}, in the same order,
+     * coverted to wrapper objects.
+     */
+    @Nonnull
+    public static List<Byte> asList(byte... primitiveArray) {
+        checkNotNull(primitiveArray, "primitiveArray");
+
+        if (primitiveArray.length == 0) {
+            return Collections.emptyList();
+        }
+        List<Byte> byteCollection = new ArrayList<>(primitiveArray.length);
+        for (byte each : primitiveArray) {
+            byteCollection.add(new Byte(each));
+        }
+        return byteCollection;
+    }
+
+
+    /**
+     * Converts a {@link List} of {@link Byte} into a {@code byte} array.
+     *
+     * @param boxedList the {@link List} of {@link Byte} to convert.
+     * @return an array containing the same elements as {@code boxedList}, in the same order, converted to primitives.
+     */
+    @Nonnull
+    public static byte[] toArray(List<Byte> boxedList) {
+        checkNotNull(boxedList, "boxedList");
+
+        int i = 0;
+        byte[] elements = new byte[boxedList.size()];
+        for (Byte each : boxedList) {
+            elements[i++] = each.byteValue();
+        }
+        return elements;
+    }
+
 }

--- a/commons-core/src/test/java/fr/inria/atlanmod/commons/collect/MoreArraysTest.java
+++ b/commons-core/src/test/java/fr/inria/atlanmod/commons/collect/MoreArraysTest.java
@@ -185,4 +185,20 @@ public class MoreArraysTest extends AbstractTest {
 
         assertThat(MoreArrays.lastIndexOf(array0, 10)).isEqualTo(MoreArrays.NO_INDEX);
     }
+
+    @Test
+    public void testBytesToPrimitive() {
+        Byte[] boxedArray = new Byte[] {0, 1, 2, 3, 4};
+        byte[] primitiveArray = new byte[] {0, 1, 2, 3, 4};
+
+        assertThat(primitiveArray).isEqualTo(MoreArrays.toPrimitive(boxedArray));
+    }
+
+    @Test
+    public void testBytesToObject() {
+        Byte[] boxedArray = new Byte[] {0, 1, 2, 3, 4};
+        byte[] primitiveArray = new byte[] {0, 1, 2, 3, 4};
+
+        assertThat(boxedArray).isEqualTo(MoreArrays.toObject(primitiveArray));
+    }
 }

--- a/commons-core/src/test/java/fr/inria/atlanmod/commons/collect/MoreArraysTest.java
+++ b/commons-core/src/test/java/fr/inria/atlanmod/commons/collect/MoreArraysTest.java
@@ -126,6 +126,17 @@ public class MoreArraysTest extends AbstractTest {
     }
 
     @Test
+    public void testAddAllBytes() {
+        byte[] array1 = new byte[] {6,5,4,3,2,1};
+        byte[] array2 = new byte[] {1, 2, 3};
+        byte[] expected = new byte[] {6,5,4,3,2,1,1,2,3};
+
+        byte[] joinedArray = MoreArrays.addAll(array1, array2);
+
+        assertThat(joinedArray).isEqualTo(expected);
+    }
+
+    @Test
     public void testRemove() {
         Integer[] array0 = new Integer[]{0, 1, 2, 3, 4};
         assertThat(array0).hasSize(5);

--- a/commons-core/src/test/java/fr/inria/atlanmod/commons/primitive/BytesTest.java
+++ b/commons-core/src/test/java/fr/inria/atlanmod/commons/primitive/BytesTest.java
@@ -124,7 +124,7 @@ public class BytesTest extends AbstractTest {
         byte[] expected = new byte[] {1, 2, 3, 4, 5};
         List<Byte> boxedList = new ArrayList<>();
         for(byte each : expected) {
-            boxedList.add(new Byte(each));
+            boxedList.add(Byte.valueOf(each));
         }
         assertThat(boxedList.size()).isEqualTo(expected.length);
         assertThat(Bytes.toArray(boxedList)).isEqualTo(expected);

--- a/commons-core/src/test/java/fr/inria/atlanmod/commons/primitive/BytesTest.java
+++ b/commons-core/src/test/java/fr/inria/atlanmod/commons/primitive/BytesTest.java
@@ -13,6 +13,8 @@ import fr.inria.atlanmod.commons.AbstractTest;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -101,5 +103,30 @@ public class BytesTest extends AbstractTest {
         assertThat(actualBytes0).contains(bytes);
 
         assertThat(Bytes.toString(actualBytes0)).isEqualTo(expected0);
+    }
+
+    @Test
+    public void testAsList() {
+        byte[] bytes = new byte[] {1, 2, 3, 4, 5};
+        List<Byte> boxedList = Bytes.asList(bytes);
+
+        assertThat(boxedList.size()).isEqualTo(bytes.length);
+
+        List<Byte> expected = new ArrayList<>(bytes.length);
+        for(byte each : bytes) {
+            expected.add(each);
+        }
+        assertThat(expected).isEqualTo(boxedList);
+    }
+
+    @Test
+    public void testToArray() {
+        byte[] expected = new byte[] {1, 2, 3, 4, 5};
+        List<Byte> boxedList = new ArrayList<>();
+        for(byte each : expected) {
+            boxedList.add(new Byte(each));
+        }
+        assertThat(boxedList.size()).isEqualTo(expected.length);
+        assertThat(Bytes.toArray(boxedList)).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
Methods that convert arrays of primitive types into arrays of boxed types (and vice-versa), and methods that convert Lists of boxed types to arrays of primitive types (and vice-versa).